### PR TITLE
Import Optuna matplotlib plotting functions to fix optimization plotting NameError

### DIFF
--- a/pathbench/benchmarking/benchmark.py
+++ b/pathbench/benchmarking/benchmark.py
@@ -41,7 +41,7 @@ from sklearn.metrics import (
 )
 from sklearn.preprocessing import label_binarize
 import optuna
-import optuna.visualization as opt_vis
+from optuna.visualization.matplotlib import plot_param_importances, plot_optimization_history
 from optuna.samplers import TPESampler
 from optuna.pruners import HyperbandPruner
 


### PR DESCRIPTION
### Motivation

- The optimization pipeline raised a `NameError` for `plot_param_importances` during the optimization step, causing optimization mode to crash and preventing saving of output plots. 
- The change aims to ensure all optimization-mode outputs (parameter importances and optimization history) are plotted and saved correctly. 

### Description

- Replace the unused generic `optuna.visualization` import with explicit matplotlib plotting functions by adding `from optuna.visualization.matplotlib import plot_param_importances, plot_optimization_history`.
- This enables the existing `plot_optimization_output` function to call `plot_param_importances` and `plot_optimization_history` and save the resulting figures without raising `NameError`.
- Modified file: `pathbench/benchmarking/benchmark.py` to add the correct imports.

### Testing

- Running the project's automated test script `python test/test.py` prior to the change reproduced the failure with `NameError: name 'plot_param_importances' is not defined` during optimization.
- No automated tests were executed after applying the import fix during this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960b7c394ac832fa9c2185141314651)